### PR TITLE
fix: fix musl link and add test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: Test build Snap
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
+      id: snapcraft
+  required_status_checks:
+    name: Required Build Test Status Check
+    runs-on: ubuntu-latest
+    needs:
+      - build-test
+    if: always() && !cancelled()
+    timeout-minutes: 5
+    steps:
+      - run: |
+          [ '${{ needs.build-test.result }}' = 'success' ] || (echo build-test failed && false)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -71,6 +71,7 @@ parts:
       mv node_modules app/
       mv lib app/
       mv app/ $CRAFT_PRIME/
+      ln -srf $SNAPCRAFT_PART_INSTALL/lib/x86_64-linux-musl/libc.so $SNAPCRAFT_PART_INSTALL/lib/libc.musl-x86_64.so.1
     stage-packages: [sipcalc, iproute2, openssl, libatm1, musl]
   matrix-appservice-irc-wrapper:
     after: [node, freebindfree, matrix-appservice-irc]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: matrix-appservice-irc


### PR DESCRIPTION
This PR fixes the warning:

```
Lint warnings:
- library: app/node_modules/utf-8-validate/prebuilds/linux-x64/node.napi.musl.node: missing dependency 'libc.musl-x86_64.so.1'. (https://snapcraft.io/docs/linters-library)
```

That is making the build fail.

Also adds a test to prevent PRs from being merged if there are errors while building the snap.